### PR TITLE
📝 Update workflow and django versions

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -22,6 +22,7 @@ jobs:
           - "2.1"
           - "2.2"
           - "3.0"
+          - "3.1"
         exclude:
           # Python 2.7 is compatible with Django 1.11
           - python-version: "2.7"
@@ -32,9 +33,13 @@ jobs:
             django-version: "2.2"
           - python-version: "2.7"
             django-version: "3.0"
+          - python-version: "2.7"
+            django-version: "3.1"
           # Python 3.5 is compatible with Django <3.0
           - python-version: "3.5"
             django-version: "3.0"
+          - python-version: "3.5"
+            django-version: "3.1"
           # Python 3.8 is compatible with Django 2.2+
           - python-version: "3.8"
             django-version: "1.11"
@@ -44,10 +49,10 @@ jobs:
             django-version: "2.1"
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
Thanks for creating this example. I found it really useful and would have copied it 1:1 if I hadn't just upgraded my `setup-python` and `checkout` workflows in another project.

-----------

This PR updates package versions that have been introduced after this repo was created, to make the workflow more (hopefully completely) up to date.

It upgrades:

- [setup-python](https://github.com/actions/setup-python) from `v1` to `v2`, and 
- [checkout](https://github.com/actions/checkout) from `v1` to `v2`. 

Also added Django 3.1 and excluded it from the 2.7 and 3.5 python combinations. 

From the [Django 3.1 release notes](https://docs.djangoproject.com/en/3.1/releases/3.1/) it looks like all other combinations should be fine, but I've not tested it.